### PR TITLE
Updated plugin.py to use a ZWS for noHighlight

### DIFF
--- a/RelayNext/plugin.py
+++ b/RelayNext/plugin.py
@@ -129,7 +129,7 @@ class RelayNext(callbacks.Plugin):
         # Attempt to mitigate highlights (for some clients) by adding
         # a hyphen in front of the nick.
         if noHighlight:
-            nick = '-' + nick
+            nick = (nick[0] + "\u200b" + nick[1:] if len(nick) > 0 else "")
 
         # Skip hostmask checking if the sender is a server
         # (i.e. a '.' is present in their name)


### PR DESCRIPTION
For the `noHighlight` option, many clients still ping even by adding a hyphen at the first of the nick

The much better solution is to add `\u200b` (Zero-Width space) somewhere in the middle of the nickname, all I did was changing the hyphen to become a ZWS in the middle of the nick. Now we can be sure that all clients don't highlight and everything is good and constant and there's no visual impact.